### PR TITLE
Add auth to backend for webapp landing page

### DIFF
--- a/webapp/src/scenes/Auth/Auth.tsx
+++ b/webapp/src/scenes/Auth/Auth.tsx
@@ -1,17 +1,56 @@
 import { useState } from 'react'
-import { useSearchParams, Link } from 'react-router-dom'
+import { useSearchParams, useNavigate, Link } from 'react-router-dom'
 import './Auth.css'
 
 function Auth() {
   const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
   const isSignUp = searchParams.get('mode') === 'signup'
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [name, setName] = useState('')
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setError('')
+    setSubmitting(true)
+
+    try {
+      if (isSignUp) {
+        const registerRes = await fetch('/api/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password }),
+        })
+        if (!registerRes.ok) {
+          const body = await registerRes.json().catch(() => ({}))
+          setError(body.error ?? 'Sign up failed')
+          return
+        }
+      }
+
+      const loginRes = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      })
+      if (!loginRes.ok) {
+        const body = await loginRes.json().catch(() => ({}))
+        setError(body.error ?? 'Sign in failed')
+        return
+      }
+
+      const { token } = await loginRes.json()
+      localStorage.setItem('token', token)
+      navigate('/projects')
+    } catch {
+      setError('Network error — is the server running?')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -58,7 +97,9 @@ function Auth() {
             />
           </div>
 
-          <button type="submit" className="auth-button">
+          {error && <p className="auth-error" role="alert">{error}</p>}
+
+          <button type="submit" className="auth-button" disabled={submitting}>
             {isSignUp ? 'Sign Up' : 'Sign In'}
           </button>
         </form>

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -5,6 +5,11 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
This PR implements auth functionality for the landing page on the webapp. 

To test:
* Run the webapp
* Click sign up and create a user
* You should be redirected to the projects page
* Navigate to the homepage again by removing `/projects` from the URL (no 'logout' button yet - next PR)
* Try to sign in with the user credentials you just created, it should be successful
* Try to sign in again with invalid/ random user credentials, it should say 'Invalid credentials' and not redirect to the project page